### PR TITLE
Update forging sketches to match example

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,26 +557,39 @@
                 <div class="flex-row compact-flex">
                     <div class="sketch-block">
                         <svg width="320" height="140" viewBox="0 0 320 140">
+  <defs>
+    <pattern id="hatch_krug" width="4" height="4" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="4" stroke="#ccc" stroke-width="0.5"/>
+    </pattern>
+  </defs>
   <!-- Вид сбоку -->
   <g>
-    <rect x="20" y="35" width="120" height="50" rx="8" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <rect x="32" y="45" width="96" height="30" rx="4" fill="none" stroke="#222" stroke-width="1.5" />
-    <line x1="10" y1="60" x2="150" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <line x1="20" y1="110" x2="140" y2="110" stroke="#222" stroke-width="1.5" />
-    <path d="M23 107 L20 110 L23 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M137 107 L140 110 L137 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="80" y="132" font-size="18" text-anchor="middle" fill="#222" font-style="italic">L</text>
+    <!-- Основной контур -->
+    <rect x="20" y="35" width="120" height="50" fill="#fff" stroke="#000" stroke-width="2"/>
+    <!-- Осевая линия -->
+    <line x1="10" y1="60" x2="150" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <!-- Размерная линия L -->
+    <line x1="20" y1="110" x2="140" y2="110" stroke="#000" stroke-width="1.5"/>
+    <path d="M23 107 L20 110 L23 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M137 107 L140 110 L137 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="80" y="132" font-size="16" text-anchor="middle" fill="#000" font-weight="bold">L</text>
+    <!-- Штриховка -->
+    <rect x="20" y="35" width="120" height="50" fill="url(#hatch_krug)" stroke="none"/>
   </g>
   <!-- Вид спереди -->
   <g>
-    <circle cx="240" cy="60" r="28" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <circle cx="240" cy="60" r="20" fill="none" stroke="#222" stroke-width="1.5" />
-    <line x1="200" y1="60" x2="280" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <line x1="240" y1="32" x2="240" y2="88" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <line x1="212" y1="110" x2="268" y2="110" stroke="#222" stroke-width="1.5" />
-    <path d="M215 107 L212 110 L215 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M265 107 L268 110 L265 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="240" y="132" font-size="18" text-anchor="middle" fill="#222" font-style="italic">D</text>
+    <!-- Основной круг -->
+    <circle cx="240" cy="60" r="28" fill="#fff" stroke="#000" stroke-width="2"/>
+    <!-- Осевые линии -->
+    <line x1="200" y1="60" x2="280" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <line x1="240" y1="32" x2="240" y2="88" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <!-- Размерная линия D -->
+    <line x1="212" y1="110" x2="268" y2="110" stroke="#000" stroke-width="1.5"/>
+    <path d="M215 107 L212 110 L215 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M265 107 L268 110 L265 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="240" y="132" font-size="16" text-anchor="middle" fill="#000" font-weight="bold">D</text>
+    <!-- Штриховка -->
+    <circle cx="240" cy="60" r="28" fill="url(#hatch_krug)" stroke="none"/>
   </g>
 </svg>
                         <div class="extra-info">
@@ -665,30 +678,44 @@
                 <div class="flex-row compact-flex">
                     <div class="sketch-block">
                         <svg width="320" height="140" viewBox="0 0 320 140">
+  <defs>
+    <pattern id="hatch_pryam" width="4" height="4" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="4" stroke="#ccc" stroke-width="0.5"/>
+    </pattern>
+  </defs>
   <!-- Вид сбоку -->
   <g>
-    <rect x="20" y="35" width="120" height="50" rx="8" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <rect x="32" y="45" width="96" height="30" rx="4" fill="none" stroke="#222" stroke-width="1.5" />
-    <line x1="10" y1="60" x2="150" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <line x1="20" y1="110" x2="140" y2="110" stroke="#222" stroke-width="1.5" />
-    <path d="M23 107 L20 110 L23 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M137 107 L140 110 L137 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="80" y="132" font-size="18" text-anchor="middle" fill="#222" font-style="italic">L</text>
+    <!-- Основной контур -->
+    <rect x="20" y="35" width="120" height="50" fill="#fff" stroke="#000" stroke-width="2"/>
+    <!-- Осевая линия -->
+    <line x1="10" y1="60" x2="150" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <!-- Размерная линия L -->
+    <line x1="20" y1="110" x2="140" y2="110" stroke="#000" stroke-width="1.5"/>
+    <path d="M23 107 L20 110 L23 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M137 107 L140 110 L137 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="80" y="132" font-size="16" text-anchor="middle" fill="#000" font-weight="bold">L</text>
+    <!-- Штриховка -->
+    <rect x="20" y="35" width="120" height="50" fill="url(#hatch_pryam)" stroke="none"/>
   </g>
   <!-- Вид спереди -->
   <g>
-    <rect x="210" y="45" width="50" height="30" rx="8" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <rect x="220" y="53" width="30" height="14" rx="4" fill="none" stroke="#222" stroke-width="1.5" />
-    <line x1="210" y1="60" x2="260" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <line x1="235" y1="45" x2="235" y2="75" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <line x1="210" y1="110" x2="260" y2="110" stroke="#222" stroke-width="1.5" />
-    <path d="M213 107 L210 110 L213 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M257 107 L260 110 L257 113" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="235" y="132" font-size="18" text-anchor="middle" fill="#222" font-style="italic">B</text>
-    <line x1="270" y1="45" x2="270" y2="75" stroke="#222" stroke-width="1.5" />
-    <path d="M267 48 L270 45 L273 48" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M267 72 L270 75 L273 72" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="282" y="62" font-size="18" text-anchor="start" fill="#222" font-style="italic">H</text>
+    <!-- Основной прямоугольник -->
+    <rect x="210" y="45" width="50" height="30" fill="#fff" stroke="#000" stroke-width="2"/>
+    <!-- Осевые линии -->
+    <line x1="210" y1="60" x2="260" y2="60" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <line x1="235" y1="45" x2="235" y2="75" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <!-- Размерная линия B -->
+    <line x1="210" y1="110" x2="260" y2="110" stroke="#000" stroke-width="1.5"/>
+    <path d="M213 107 L210 110 L213 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M257 107 L260 110 L257 113" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="235" y="132" font-size="16" text-anchor="middle" fill="#000" font-weight="bold">B</text>
+    <!-- Размерная линия H -->
+    <line x1="270" y1="45" x2="270" y2="75" stroke="#000" stroke-width="1.5"/>
+    <path d="M267 48 L270 45 L273 48" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M267 72 L270 75 L273 72" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="282" y="62" font-size="16" text-anchor="start" fill="#000" font-weight="bold">H</text>
+    <!-- Штриховка -->
+    <rect x="210" y="45" width="50" height="30" fill="url(#hatch_pryam)" stroke="none"/>
   </g>
 </svg>
                         <div class="extra-info">
@@ -778,51 +805,47 @@
                     <div class="sketch-block">
                         <svg width="340" height="120" viewBox="0 0 340 120">
   <defs>
-    <pattern id="hatch_cyl" width="6" height="6" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
-      <rect x="0" y="0" width="3" height="6" fill="#fff" />
-      <rect x="3" y="0" width="3" height="6" fill="#e0e0e0" />
+    <pattern id="hatch_cyl" width="4" height="4" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="4" stroke="#ccc" stroke-width="0.5"/>
     </pattern>
   </defs>
   <!-- Вид сбоку -->
   <g>
     <!-- Наружный контур -->
-    <rect x="20" y="30" width="130" height="50" fill="url(#hatch_cyl)" stroke="#222" stroke-width="1.5" />
+    <rect x="20" y="30" width="130" height="50" fill="#fff" stroke="#000" stroke-width="2"/>
     <!-- Внутренний контур (отверстие) -->
-    <rect x="50" y="45" width="70" height="20" fill="#fff" stroke="#222" stroke-width="1.5" />
+    <rect x="50" y="45" width="70" height="20" fill="#fff" stroke="#000" stroke-width="2"/>
     <!-- Осевая линия -->
-    <line x1="20" y1="55" x2="150" y2="55" stroke="#888" stroke-width="1" stroke-dasharray="5,4" />
+    <line x1="20" y1="55" x2="150" y2="55" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
     <!-- Размер d -->
-    <line x1="50" y1="25" x2="50" y2="45" stroke="#222" stroke-width="1.5" />
-    <!-- Левая стрелка d -->
-    <path d="M47 28 L50 25 L53 28" fill="none" stroke="#222" stroke-width="1.5" />
-    <!-- Правая стрелка d -->
-    <path d="M47 42 L50 45 L53 42" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="44" y="20" font-size="13" text-anchor="end" fill="#222" font-style="italic">d</text>
+    <line x1="50" y1="25" x2="50" y2="45" stroke="#000" stroke-width="1.5"/>
+    <path d="M47 28 L50 25 L53 28" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M47 42 L50 45 L53 42" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="44" y="20" font-size="14" text-anchor="end" fill="#000" font-weight="bold">d</text>
     <!-- Размер L -->
-    <line x1="20" y1="105" x2="150" y2="105" stroke="#222" stroke-width="1.5" />
-    <!-- Левая стрелка L -->
-    <path d="M23 102 L20 105 L23 108" fill="none" stroke="#222" stroke-width="1.5" />
-    <!-- Правая стрелка L -->
-    <path d="M147 102 L150 105 L147 108" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="85" y="118" font-size="13" text-anchor="middle" fill="#222" font-style="italic">L</text>
+    <line x1="20" y1="105" x2="150" y2="105" stroke="#000" stroke-width="1.5"/>
+    <path d="M23 102 L20 105 L23 108" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M147 102 L150 105 L147 108" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="85" y="118" font-size="14" text-anchor="middle" fill="#000" font-weight="bold">L</text>
+    <!-- Штриховка -->
+    <rect x="20" y="30" width="130" height="50" fill="url(#hatch_cyl)" stroke="none"/>
   </g>
   <!-- Вид спереди -->
   <g>
     <!-- Наружный круг -->
-    <circle cx="250" cy="55" r="35" fill="#fff" stroke="#222" stroke-width="1.5" />
+    <circle cx="250" cy="55" r="35" fill="#fff" stroke="#000" stroke-width="2"/>
     <!-- Внутренний круг -->
-    <circle cx="250" cy="55" r="17" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <!-- Осевая линия горизонтальная -->
-    <line x1="215" y1="55" x2="285" y2="55" stroke="#888" stroke-width="1" stroke-dasharray="5,4" />
-    <!-- Осевая линия вертикальная -->
-    <line x1="250" y1="20" x2="250" y2="90" stroke="#888" stroke-width="1" stroke-dasharray="5,4" />
+    <circle cx="250" cy="55" r="17" fill="#fff" stroke="#000" stroke-width="2"/>
+    <!-- Осевые линии -->
+    <line x1="215" y1="55" x2="285" y2="55" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <line x1="250" y1="20" x2="250" y2="90" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
     <!-- Размер D -->
-    <line x1="285" y1="105" x2="215" y2="105" stroke="#222" stroke-width="1.5" />
-    <!-- Левая стрелка D -->
-    <path d="M218 102 L215 105 L218 108" fill="none" stroke="#222" stroke-width="1.5" />
-    <!-- Правая стрелка D -->
-    <path d="M282 102 L285 105 L282 108" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="250" y="118" font-size="13" text-anchor="middle" fill="#222" font-style="italic">D</text>
+    <line x1="285" y1="105" x2="215" y2="105" stroke="#000" stroke-width="1.5"/>
+    <path d="M218 102 L215 105 L218 108" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M282 102 L285 105 L282 108" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="250" y="118" font-size="14" text-anchor="middle" fill="#000" font-weight="bold">D</text>
+    <!-- Штриховка -->
+    <circle cx="250" cy="55" r="35" fill="url(#hatch_cyl)" stroke="none"/>
   </g>
 </svg>
                         <div class="extra-info">
@@ -912,43 +935,45 @@
                     <div class="sketch-block">
                         <svg width="320" height="180" viewBox="0 0 320 180">
   <defs>
-    <pattern id="hatch_disk2" width="6" height="6" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
-      <rect x="0" y="0" width="3" height="6" fill="#fff" />
-      <rect x="3" y="0" width="3" height="6" fill="#e0e0e0" />
+    <pattern id="hatch_disk" width="4" height="4" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="4" stroke="#ccc" stroke-width="0.5"/>
     </pattern>
   </defs>
   <!-- Левый вид (сбоку) -->
   <g>
-    <rect x="40" y="20" width="40" height="120" fill="#fff" stroke="#222" stroke-width="2" />
-    <rect x="40" y="20" width="40" height="40" fill="url(#hatch_disk2)" stroke="none" />
-    <rect x="40" y="100" width="40" height="40" fill="url(#hatch_disk2)" stroke="none" />
-    <line x1="0" y1="80" x2="120" y2="80" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <line x1="35" y1="65" x2="35" y2="95" stroke="#222" stroke-width="1.5" />
-    <path d="M32 68 L35 65 L38 68" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M32 92 L35 95 L38 92" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="28" y="82" font-size="15" text-anchor="middle" fill="#222" font-style="italic">d</text>
-    <line x1="40" y1="150" x2="80" y2="150" stroke="#222" stroke-width="1.5" />
-    <path d="M43 147 L40 150 L43 153" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M77 147 L80 150 L77 153" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="60" y="165" font-size="15" text-anchor="middle" fill="#222" font-style="italic">H</text>
+    <!-- Основной контур -->
+    <rect x="40" y="20" width="40" height="120" fill="#fff" stroke="#000" stroke-width="2"/>
+    <!-- Осевая линия -->
+    <line x1="0" y1="80" x2="120" y2="80" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <!-- Размерная линия d -->
+    <line x1="35" y1="65" x2="35" y2="95" stroke="#000" stroke-width="1.5"/>
+    <path d="M32 68 L35 65 L38 68" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M32 92 L35 95 L38 92" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="28" y="82" font-size="14" text-anchor="middle" fill="#000" font-weight="bold">d</text>
+    <!-- Размерная линия H -->
+    <line x1="40" y1="150" x2="80" y2="150" stroke="#000" stroke-width="1.5"/>
+    <path d="M43 147 L40 150 L43 153" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M77 147 L80 150 L77 153" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="60" y="165" font-size="14" text-anchor="middle" fill="#000" font-weight="bold">H</text>
+    <!-- Штриховка -->
+    <rect x="40" y="20" width="40" height="120" fill="url(#hatch_disk)" stroke="none"/>
   </g>
   <!-- Правый вид (спереди) -->
   <g>
     <!-- Наружный круг -->
-    <circle cx="230" cy="80" r="40" fill="#fff" stroke="#222" stroke-width="1.5" />
+    <circle cx="230" cy="80" r="40" fill="#fff" stroke="#000" stroke-width="2"/>
     <!-- Внутренний круг -->
-    <circle cx="230" cy="80" r="15" fill="#fff" stroke="#222" stroke-width="1.2" />
-    <!-- Осевая линия горизонтальная -->
-    <line x1="190" y1="80" x2="270" y2="80" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
-    <!-- Осевая линия вертикальная -->
-    <line x1="230" y1="40" x2="230" y2="120" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
+    <circle cx="230" cy="80" r="15" fill="#fff" stroke="#000" stroke-width="2"/>
+    <!-- Осевые линии -->
+    <line x1="190" y1="80" x2="270" y2="80" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
+    <line x1="230" y1="40" x2="230" y2="120" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
     <!-- Размер D -->
-    <line x1="190" y1="150" x2="270" y2="150" stroke="#222" stroke-width="1.5" />
-    <!-- Левая стрелка D -->
-    <path d="M193 147 L190 150 L193 153" fill="none" stroke="#222" stroke-width="1.5" />
-    <!-- Правая стрелка D -->
-    <path d="M267 147 L270 150 L267 153" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="230" y="165" font-size="15" text-anchor="middle" fill="#222" font-style="italic">D</text>
+    <line x1="190" y1="150" x2="270" y2="150" stroke="#000" stroke-width="1.5"/>
+    <path d="M193 147 L190 150 L193 153" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M267 147 L270 150 L267 153" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="230" y="165" font-size="14" text-anchor="middle" fill="#000" font-weight="bold">D</text>
+    <!-- Штриховка -->
+    <circle cx="230" cy="80" r="40" fill="url(#hatch_disk)" stroke="none"/>
   </g>
 </svg>
                         <div class="extra-info">
@@ -1037,69 +1062,80 @@
                 <div class="flex-row compact-flex">
                     <div class="sketch-block">
                         <svg width="500" height="160" viewBox="0 0 500 160">
+  <defs>
+    <pattern id="hatch_val" width="4" height="4" patternTransform="rotate(45 0 0)" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="4" stroke="#ccc" stroke-width="0.5"/>
+    </pattern>
+  </defs>
   <!-- Вид сбоку -->
   <g>
     <!-- Ступени вала -->
-    <rect x="20" y="60" width="40" height="40" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <rect x="60" y="50" width="50" height="60" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <rect x="110" y="45" width="60" height="70" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <rect x="170" y="40" width="70" height="80" fill="#fff" stroke="#222" stroke-width="1.5" />
-    <rect x="240" y="35" width="80" height="90" fill="#fff" stroke="#222" stroke-width="1.5" />
+    <rect x="20" y="60" width="40" height="40" fill="#fff" stroke="#000" stroke-width="2"/>
+    <rect x="60" y="50" width="50" height="60" fill="#fff" stroke="#000" stroke-width="2"/>
+    <rect x="110" y="45" width="60" height="70" fill="#fff" stroke="#000" stroke-width="2"/>
+    <rect x="170" y="40" width="70" height="80" fill="#fff" stroke="#000" stroke-width="2"/>
+    <rect x="240" y="35" width="80" height="90" fill="#fff" stroke="#000" stroke-width="2"/>
     
     <!-- Осевая линия -->
-    <line x1="10" y1="80" x2="450" y2="80" stroke="#888" stroke-width="1" stroke-dasharray="6,5" />
+    <line x1="10" y1="80" x2="450" y2="80" stroke="#888" stroke-width="1" stroke-dasharray="8,4"/>
     
     <!-- Размеры ступеней -->
-    <line x1="40" y1="95" x2="40" y2="65" stroke="#222" stroke-width="1.5" />
-    <path d="M37 68 L40 65 L43 68" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M37 92 L40 95 L43 92" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="35" y="85" font-size="12" text-anchor="end" fill="#222" font-style="italic">D1</text>
+    <line x1="40" y1="95" x2="40" y2="65" stroke="#000" stroke-width="1.5"/>
+    <path d="M37 68 L40 65 L43 68" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M37 92 L40 95 L43 92" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="35" y="85" font-size="12" text-anchor="end" fill="#000" font-weight="bold">D1</text>
     
-    <line x1="85" y1="105" x2="85" y2="55" stroke="#222" stroke-width="1.5" />
-    <path d="M82 58 L85 55 L88 58" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M82 102 L85 105 L88 102" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="80" y="95" font-size="12" text-anchor="end" fill="#222" font-style="italic">D2</text>
+    <line x1="85" y1="105" x2="85" y2="55" stroke="#000" stroke-width="1.5"/>
+    <path d="M82 58 L85 55 L88 58" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M82 102 L85 105 L88 102" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="80" y="95" font-size="12" text-anchor="end" fill="#000" font-weight="bold">D2</text>
     
-    <line x1="140" y1="110" x2="140" y2="50" stroke="#222" stroke-width="1.5" />
-    <path d="M137 53 L140 50 L143 53" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M137 107 L140 110 L143 107" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="135" y="100" font-size="12" text-anchor="end" fill="#222" font-style="italic">D3</text>
+    <line x1="140" y1="110" x2="140" y2="50" stroke="#000" stroke-width="1.5"/>
+    <path d="M137 53 L140 50 L143 53" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M137 107 L140 110 L143 107" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="135" y="100" font-size="12" text-anchor="end" fill="#000" font-weight="bold">D3</text>
     
-    <line x1="205" y1="115" x2="205" y2="45" stroke="#222" stroke-width="1.5" />
-    <path d="M202 48 L205 45 L208 48" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M202 112 L205 115 L208 112" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="200" y="105" font-size="12" text-anchor="end" fill="#222" font-style="italic">D4</text>
+    <line x1="205" y1="115" x2="205" y2="45" stroke="#000" stroke-width="1.5"/>
+    <path d="M202 48 L205 45 L208 48" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M202 112 L205 115 L208 112" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="200" y="105" font-size="12" text-anchor="end" fill="#000" font-weight="bold">D4</text>
     
-    <line x1="280" y1="120" x2="280" y2="40" stroke="#222" stroke-width="1.5" />
-    <path d="M277 43 L280 40 L283 43" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M277 117 L280 120 L283 117" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="275" y="110" font-size="12" text-anchor="end" fill="#222" font-style="italic">D5</text>
+    <line x1="280" y1="120" x2="280" y2="40" stroke="#000" stroke-width="1.5"/>
+    <path d="M277 43 L280 40 L283 43" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M277 117 L280 120 L283 117" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="275" y="110" font-size="12" text-anchor="end" fill="#000" font-weight="bold">D5</text>
     
     <!-- Размеры длин -->
-    <line x1="20" y1="140" x2="60" y2="140" stroke="#222" stroke-width="1.5" />
-    <path d="M23 137 L20 140 L23 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M57 137 L60 140 L57 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="40" y="155" font-size="12" text-anchor="middle" fill="#222" font-style="italic">L1</text>
+    <line x1="20" y1="140" x2="60" y2="140" stroke="#000" stroke-width="1.5"/>
+    <path d="M23 137 L20 140 L23 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M57 137 L60 140 L57 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="40" y="155" font-size="12" text-anchor="middle" fill="#000" font-weight="bold">L1</text>
     
-    <line x1="60" y1="140" x2="110" y2="140" stroke="#222" stroke-width="1.5" />
-    <path d="M63 137 L60 140 L63 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M107 137 L110 140 L107 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="85" y="155" font-size="12" text-anchor="middle" fill="#222" font-style="italic">L2</text>
+    <line x1="60" y1="140" x2="110" y2="140" stroke="#000" stroke-width="1.5"/>
+    <path d="M63 137 L60 140 L63 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M107 137 L110 140 L107 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="85" y="155" font-size="12" text-anchor="middle" fill="#000" font-weight="bold">L2</text>
     
-    <line x1="110" y1="140" x2="170" y2="140" stroke="#222" stroke-width="1.5" />
-    <path d="M113 137 L110 140 L113 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M167 137 L170 140 L167 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="140" y="155" font-size="12" text-anchor="middle" fill="#222" font-style="italic">L3</text>
+    <line x1="110" y1="140" x2="170" y2="140" stroke="#000" stroke-width="1.5"/>
+    <path d="M113 137 L110 140 L113 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M167 137 L170 140 L167 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="140" y="155" font-size="12" text-anchor="middle" fill="#000" font-weight="bold">L3</text>
     
-    <line x1="170" y1="140" x2="240" y2="140" stroke="#222" stroke-width="1.5" />
-    <path d="M173 137 L170 140 L173 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M237 137 L240 140 L237 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="205" y="155" font-size="12" text-anchor="middle" fill="#222" font-style="italic">L4</text>
+    <line x1="170" y1="140" x2="240" y2="140" stroke="#000" stroke-width="1.5"/>
+    <path d="M173 137 L170 140 L173 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M237 137 L240 140 L237 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="205" y="155" font-size="12" text-anchor="middle" fill="#000" font-weight="bold">L4</text>
     
-    <line x1="240" y1="140" x2="320" y2="140" stroke="#222" stroke-width="1.5" />
-    <path d="M243 137 L240 140 L243 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <path d="M317 137 L320 140 L317 143" fill="none" stroke="#222" stroke-width="1.5" />
-    <text x="280" y="155" font-size="12" text-anchor="middle" fill="#222" font-style="italic">L5</text>
+    <line x1="240" y1="140" x2="320" y2="140" stroke="#000" stroke-width="1.5"/>
+    <path d="M243 137 L240 140 L243 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <path d="M317 137 L320 140 L317 143" fill="none" stroke="#000" stroke-width="1.5"/>
+    <text x="280" y="155" font-size="12" text-anchor="middle" fill="#000" font-weight="bold">L5</text>
+    <!-- Штриховка -->
+    <rect x="20" y="60" width="40" height="40" fill="url(#hatch_val)" stroke="none"/>
+    <rect x="60" y="50" width="50" height="60" fill="url(#hatch_val)" stroke="none"/>
+    <rect x="110" y="45" width="60" height="70" fill="url(#hatch_val)" stroke="none"/>
+    <rect x="170" y="40" width="70" height="80" fill="url(#hatch_val)" stroke="none"/>
+    <rect x="240" y="35" width="80" height="90" fill="url(#hatch_val)" stroke="none"/>
   </g>
 </svg>
                         <div class="extra-info">


### PR DESCRIPTION
Replace existing SVG sketches for various forging types with professional technical drawings.

The sketches were updated to a uniform professional style with improved hatching, clearer lines, standardized colors, and bold typography for dimensions, aligning with the quality of the provided example.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f6616e0-6144-4134-851f-cca4acaab76a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f6616e0-6144-4134-851f-cca4acaab76a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

